### PR TITLE
Wait forever when timeout parameter is not specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Usage: just-wait [options]
     -p, --pattern <pattern>     glob pattern. "," separates multiple patterns.
                                 More info: https://github.com/isaacs/minimatch
     -d, --delay <milliseconds>  delay returning for a number of milliseconds
-    -t, --timeout <seconds>     timeout waiting after a number of seconds (default=30)
+    -t, --timeout <seconds>     timeout waiting after a number of seconds (not specified => forever; -t without value => 30)
     -s, --silent                suppress logging.
 
   Examples:
@@ -123,4 +123,4 @@ Special thanks to [Mark Reynolds](https://github.com/lostthetrail) for making al
 ## License
 * [Creative Commons Attribution 4.0 (CC-BY-4.0)](https://creativecommons.org/licenses/by/4.0/) (this project)
 * [BSD 3-Clause license](https://opensource.org/licenses/BSD-3-Clause) (wait-run)
-* [MIT License](https://opensource.org/licenses/MIT) (watch-run)
+* [MIT License](https://opensource.org/licenses/MIT) (watch-run)

--- a/bin/just-wait.js
+++ b/bin/just-wait.js
@@ -28,7 +28,7 @@ program
 	.option('-p, --pattern <pattern>', 'glob pattern. "," separates multiple patterns.\n' +
 		'                            More info: https://github.com/isaacs/minimatch', list, '**')
 	.option('-d, --delay <milliseconds>', 'delay returning for a number of milliseconds', parseInt)
-	.option('-t, --timeout <seconds>', 'timeout waiting after a number of seconds (default=30)', parseInt)
+	.option('-t, --timeout <seconds>', 'timeout waiting after a number of seconds (not specified => forever; -t without value => 30)', parseInt)
 	.option('-s, --silent', 'suppress logging.')
 
 /**
@@ -56,20 +56,24 @@ program.parse(process.argv);
 
 var
 delay = program.delay || 0,
-timeout = program.timeout || 30,
+timeout = program.timeout,
 silent = program.silent || false,
 pattern = program.pattern;
 
+if (typeof timeout === 'number' && isNaN(timeout)) {timeout = 30;}
+
 if (!silent) {
-	log.info(wb('Waiting ') + wh('for %s (max %d seconds)'), pattern, timeout);
+	log.info(wb('Waiting ') + wh('for %s (' + (typeof timeout === 'number'?'max %d seconds':'forever') + ')'), pattern, timeout);
 }
 
-setTimeout(function(){
-	if (!silent) {
-		log.error(chalk.red.bold('Timed out ') + chalk.red('waiting for %s after %d seconds.'), pattern, timeout);
-	}
-	process.exit(1);
-}, timeout * 1000);
+if (typeof timeout === 'number') {
+	setTimeout(function(){
+		if (!silent) {
+			log.error(chalk.red.bold('Timed out ') + chalk.red('waiting for %s after %d seconds.'), pattern, timeout);
+		}
+		process.exit(1);
+	}, timeout * 1000);
+}
 
 /**
  * Watch.


### PR DESCRIPTION
Hint: I'd suggest a major version change for this, as passing no argument now means, that it waits forever. Passing `-t`without number however leads to the previons behaviour (30s).

The other way would have been to have another parameter which disables the timeout, however, that's somewhat coutner-intuitive.

This fixes #7 